### PR TITLE
The API returns a different (correct) mime-type for JSON

### DIFF
--- a/lib/wsd.js
+++ b/lib/wsd.js
@@ -86,7 +86,7 @@ exports.diagram_url = function diagram_url(description, style, format, cb) {
                 cb(er);
                 return;
             }
-            if (typ != "application/x-json") {
+            if (!(typ == "application/x-json" || typ == "application/json")) {
                 cb("Invalid MIME type for JSON: " + typ);
                 return;
             }


### PR DESCRIPTION
When calling the API, an error is printed in the console that the mime-type is incorrect. Apparently the mime-type has changes to application/json (was application/x-json).